### PR TITLE
Fix so that that cost function is used for first input

### DIFF
--- a/scripts/bestlinreg_s
+++ b/scripts/bestlinreg_s
@@ -292,7 +292,7 @@ for ($i=0; $i<=$#conf; $i++){
      }
    }
    # set up registration
-   @args = ('minctracc', '-clobber', $opt{lsqtype},
+   @args = ('minctracc', '-clobber', $opt{lsqtype}, $opt{cost_function},
             '-step', @{$conf[$i]{steps}}, '-simplex', $conf[$i]{simplex},
             '-tol', $conf[$i]{tolerance});
 


### PR DESCRIPTION
Turns out that unless you used -sec_target, -nmi wasn't being used. Fix this.