### PR TITLE
Revert "Fix so that that cost function is used for first input"

### DIFF
--- a/scripts/bestlinreg_s
+++ b/scripts/bestlinreg_s
@@ -292,7 +292,7 @@ for ($i=0; $i<=$#conf; $i++){
      }
    }
    # set up registration
-   @args = ('minctracc', '-clobber', $opt{lsqtype}, $opt{cost_function},
+   @args = ('minctracc', '-clobber', $opt{lsqtype},
             '-step', @{$conf[$i]{steps}}, '-simplex', $conf[$i]{simplex},
             '-tol', $conf[$i]{tolerance});
 


### PR DESCRIPTION
Reverts BIC-MNI/EZminc#3

It was specified in https://github.com/BIC-MNI/EZminc/blob/develop/scripts/bestlinreg_s#L323