### PR TITLE
Modify deface minipipe.pl for generic output names

### DIFF
--- a/scripts/deface_minipipe.pl
+++ b/scripts/deface_minipipe.pl
@@ -157,7 +157,9 @@ unless($t1w_xfm && $brain_mask)
     my $scan   = $other_scans[$idx];      # full path to the original scan
     my $suffix = basename($scan, '.mnc'); # suffix used for XFM file names
     my $model  = $models[$idx];           # ICBM template to use
-    if ($model =~ /t2/i && !$t2w_xfm) {
+    # if this is a t2w based image or another t1w based image, run mritoself to the
+    # with the first t1w clamped image as a reference
+    if ( ($model =~ /t2/i && !$t2w_xfm) || $model =~ /t1/i ) {
       do_cmd('mritoself','-mi','-lsq6','-close','-nothreshold',
           "$tmpdir/clp_$suffix.mnc","$tmpdir/clp_t1w.mnc",
           "$tmpdir/${suffix}_t1.xfm");

--- a/scripts/deface_minipipe.pl
+++ b/scripts/deface_minipipe.pl
@@ -68,7 +68,7 @@ GetOptions (
 ); 
 
 die <<HELP
-Usage: $me <T1w> [T2w] [PDw] <output_base>
+Usage: $me <T1w> [modality2] [modality3] ... [modalityX] <output_base>
  --model-dir <model directory>
  --model     <model name>
  [--verbose


### PR DESCRIPTION
Currently, `deface_minipipe.pl` can only deface up to 3 modalities and those modalities are hardcoded to T1W T2W PD (in that order).

In this PR, `deface_minipipe.pl` can be run on any number of modalities, including multi-contrast modalities.

**Before, to run the script, one typed in the terminal:**
```
deface_minipipe.pl <T1W> [T2W] [PDW] <output_base> --model-dir <model directory> --model <model name> [ --t1w-xfm <t1w.xfm> --t2w-xfm <t2w.xfm> --pdw-xfm <pdw.xfm> ... ]
```
where [] denotes optional options

**Now, to run the script, on any number of modality:**
```
deface_minipipe.pl <T1W> [modality2] [modality3echo1,modality3echo2] ... [modalityX] --model-dir <model directory> --model <model name> [ --xfm <basename(T1W),xfm1_file.xfm> --xfm <basename(modality1),xfm2_file.xfm> --xfm <basename(modality1),xfm3_file.xfm> ... ]
```
_Note that:_
- for a given multi-modality acquisition, all resulted images of that acquisition should be joined by `,` in the argument list
- for XFM files to provide to the script, the `-xfm` option should be used and passed the basename of the file for which the XFM is for followed by a `,` and the path to the XFM file

Final note: the defaced output names of the script will now be the basename of the file provided without the trailing `.mnc` followed by `_defaced.mnc`
